### PR TITLE
Fix API JSON format

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ CORS(app, resources={r'/*': {'origins': '*'}})
 # sanity check route
 @app.route('/ping', methods=['GET'])
 def ping_pong():
-    return jsonify('pong!')
+    return jsonify({"message": "pong!"})
 
 
 if __name__ == '__main__':

--- a/client/src/components/Ping.vue
+++ b/client/src/components/Ping.vue
@@ -20,7 +20,7 @@ export default {
       axios
         .get(path)
         .then((res) => {
-          this.msg = res.data;
+          this.msg = res.data.message;
         })
         .catch((error) => {
           // eslint-disable-next-line


### PR DESCRIPTION
## Summary
- fix ping endpoint to return JSON object
- update Ping.vue to read response object

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684410c2ead4832689b8e252c71c32bf