### PR TITLE
Remove npm test from workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,3 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test


### PR DESCRIPTION
## Summary
- simplify `node.js.yml` workflow by dropping the `npm test` step

## Testing
- `npm ci`
- `npm run build --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68441225bd708326801892dec6f82d00