### PR TITLE
Add Flask ping test

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Cors
+pytest

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app
+
+
+def test_ping_endpoint():
+    with app.test_client() as client:
+        response = client.get('/ping')
+        assert response.status_code == 200
+        assert response.get_json() == {"message": "pong!"}


### PR DESCRIPTION
## Summary
- add pytest-based ping endpoint test
- list Python dependencies
- run tests in CI using GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684412313b6c83268f28127e3f380f13